### PR TITLE
Change color palette

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -17,3 +17,38 @@
   background-color: var(--pst-color-success);
   opacity: 0.1;
 }
+
+element {
+  --pst-color-primary: #03A062;
+  --pst-color-secondary: #A00341;
+}
+
+html[data-theme=dark] {
+  --pst-color-text-base: #cecece;
+  --pst-color-text-muted: #a6a6a6;
+  --pst-color-shadow: #212121;
+  --pst-color-border: silver;
+  --pst-color-inline-code: #dd9ec2;
+  --pst-color-target: #472700;
+  --pst-color-background: #121212;
+  --pst-color-on-background: #1e1e1e;
+  --pst-color-surface: #212121;
+  --pst-color-on-surface: #373737;
+  --pst-color-link: var(--pst-color-primary);
+  --pst-color-link-hover: var(--pst-color-secondary);
+}
+
+html[data-theme=light] {
+  --pst-color-text-base: #323232;
+  --pst-color-text-muted: #646464;
+  --pst-color-shadow: #d8d8d8;
+  --pst-color-border: #c9c9c9;
+  --pst-color-inline-code: #e83e8c;
+  --pst-color-target: #fbe54e;
+  --pst-color-background: #fff;
+  --pst-color-on-background: #fff;
+  --pst-color-surface: #f5f5f5;
+  --pst-color-on-surface: #e1e1e1;
+  --pst-color-link: var(--pst-color-primary);
+  --pst-color-link-hover: var(--pst-color-secondary);
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -18,37 +18,19 @@
   opacity: 0.1;
 }
 
-element {
+:root {
   --pst-color-primary: #03A062;
-  --pst-color-secondary: #A00341;
+  --pst-color-secondary: #03A062;
 }
 
 html[data-theme=dark] {
-  --pst-color-text-base: #cecece;
-  --pst-color-text-muted: #a6a6a6;
-  --pst-color-shadow: #212121;
-  --pst-color-border: silver;
   --pst-color-inline-code: #dd9ec2;
-  --pst-color-target: #472700;
-  --pst-color-background: #121212;
-  --pst-color-on-background: #1e1e1e;
-  --pst-color-surface: #212121;
-  --pst-color-on-surface: #373737;
   --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: var(--pst-color-secondary);
 }
 
 html[data-theme=light] {
-  --pst-color-text-base: #323232;
-  --pst-color-text-muted: #646464;
-  --pst-color-shadow: #d8d8d8;
-  --pst-color-border: #c9c9c9;
   --pst-color-inline-code: #e83e8c;
-  --pst-color-target: #fbe54e;
-  --pst-color-background: #fff;
-  --pst-color-on-background: #fff;
-  --pst-color-surface: #f5f5f5;
-  --pst-color-on-surface: #e1e1e1;
   --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: var(--pst-color-secondary);
 }


### PR DESCRIPTION
We can modify `custom.css` and add the RGB codes of the colours of our chosen palette for dark and light theme.

* `--pst-color-primary` has been set to "matrix green". It is used in `h1` and `h2` html tags
* `--pst-color-inline-code` for small code snippets inline, keeping pink could be good for dark theme, and a brilliant red for the light one
* `--pst-color-secondary` used on mouse hoover, "matrix green" should be ok

I would keep the same grayscale colours of PyData theme. 

Ref: [issue #9 on troubleshooting website](https://github.com/neuroinformatics-unit/troubleshooting/issues/9)